### PR TITLE
refactor: tanstack query관련 로직 분리

### DIFF
--- a/src/api/feedApi.js
+++ b/src/api/feedApi.js
@@ -5,8 +5,9 @@ export const getFeedPages = async ({ pageParam = 1 }) => {
   return response.data;
 };
 
-export const updateThumb = async (FeedId, newThumb) => {
-  await feedInstance.patch(`/feed/${FeedId}`, { thumb: newThumb });
+export const updateThumb = async ({ feedId, currentThumb, isUserLiked, user }) => {
+  const newThumb = isUserLiked ? [...currentThumb].filter((el) => el !== user.id) : [...currentThumb, user.id];
+  await feedInstance.patch(`/feed/${feedId}`, { thumb: newThumb });
 };
 
 export const getFeedsByPageNum = async ({ pageParam = 1, userId }) => {

--- a/src/pages/feed/Posting.jsx
+++ b/src/pages/feed/Posting.jsx
@@ -1,29 +1,15 @@
 import Thumb from "./Thumb";
-import { useInfiniteQuery } from "@tanstack/react-query";
 import styled from "styled-components";
 import RidingMap from "./RidingMap";
 import { useInView } from "react-intersection-observer";
-import { getFeedPages } from "../../api/feedApi";
 import { useState } from "react";
 import ModalMap from "./ModalMap";
+import { useAllFeedsInfiniteQuery } from "../../queries/infiniteQueries";
 
 const Posting = () => {
   const { kakao } = window;
   const [selectedPost, setSelectedPost] = useState();
-
-  const {
-    data: feeds,
-    hasNextPage,
-    fetchNextPage,
-    isFetchingNextPage
-  } = useInfiniteQuery({
-    queryKey: ["feeds"],
-    queryFn: getFeedPages,
-    getNextPageParam: (lastPage, pages) => {
-      return lastPage.length === 5 ? pages.length + 1 : undefined;
-    },
-    select: (data) => data.pages.flat()
-  });
+  const { data: feeds, hasNextPage, fetchNextPage, isFetchingNextPage } = useAllFeedsInfiniteQuery();
 
   const { ref } = useInView({
     // ref element가 0.5(절반)만큼 보이면 onChange 함수 실행

--- a/src/pages/feed/Thumb.jsx
+++ b/src/pages/feed/Thumb.jsx
@@ -1,34 +1,23 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faThumbsUp as regularThumb } from "@fortawesome/free-regular-svg-icons";
 import { faThumbsUp as solidThumb } from "@fortawesome/free-solid-svg-icons";
 import styled from "styled-components";
 import useUserStore from "../../store/useUserStore";
-import feedInstance from "../../axiosInstance/feed";
+import { useThumbMutation } from "../../queries/mutaions";
 
 const Thumb = ({ currentFeedId, currentThumb }) => {
-  const queryClient = useQueryClient();
-
   const { user } = useUserStore();
+  const { mutate: addThumb } = useThumbMutation();
 
   const isUserLiked = currentThumb.some((el) => el == user?.id);
   const thumbCount = currentThumb.length;
 
-  const updateThumb = async (feedId) => {
-    const newThumb = isUserLiked ? [...currentThumb].filter((el) => el !== user.id) : [...currentThumb, user.id];
-    await feedInstance.patch(`/feed/${feedId}`, { thumb: newThumb });
-  };
-
-  const { mutate: addThumb } = useMutation({
-    mutationFn: updateThumb,
-    onSuccess: () => {
-      queryClient.invalidateQueries(["feed"]);
-    }
-  });
-
   return (
     <div>
-      <Button onClick={() => addThumb(currentFeedId)} disabled={isUserLiked ? false : true}>
+      <Button
+        onClick={() => addThumb({ feedId: currentFeedId, currentThumb, isUserLiked, user })}
+        disabled={isUserLiked ? false : true}
+      >
         {isUserLiked ? <FontAwesomeIcon icon={solidThumb} /> : <FontAwesomeIcon icon={regularThumb} />}
       </Button>
       {thumbCount}

--- a/src/queries/infiniteQueries.jsx
+++ b/src/queries/infiniteQueries.jsx
@@ -1,5 +1,5 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { getFeedsByPageNum } from "../api/feedApi";
+import { getFeedPages, getFeedsByPageNum } from "../api/feedApi";
 import useUserStore from "../store/useUserStore";
 import { queryKeys } from "./query.keys";
 
@@ -9,6 +9,17 @@ export const useMyFeedsInfiniteQuery = () => {
     queryKey: queryKeys.boardController.myFeeds(),
     queryFn: ({ pageParam = 1 }) => getFeedsByPageNum({ pageParam, userId: user.id }),
 
+    getNextPageParam: (lastPage, pages) => {
+      return lastPage.length === 5 ? pages.length + 1 : undefined;
+    },
+    select: (data) => data.pages.flat()
+  });
+};
+
+export const useAllFeedsInfiniteQuery = () => {
+  return useInfiniteQuery({
+    queryKey: queryKeys.boardController.feeds(),
+    queryFn: getFeedPages,
     getNextPageParam: (lastPage, pages) => {
       return lastPage.length === 5 ? pages.length + 1 : undefined;
     },

--- a/src/queries/mutaions.jsx
+++ b/src/queries/mutaions.jsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { deleteFn, toggleFn } from "../api/feedApi";
+import { deleteFn, toggleFn, updateThumb } from "../api/feedApi";
 import { queryKeys } from "./query.keys";
 
 export const useDeleteMyFeed = () => {
@@ -22,6 +22,16 @@ export const useToggleMyFeed = () => {
     onError: (error) => {
       alert(`현재 변경할 수 없습니다.\n잠시 후 다시 시도해주세요!`);
       console.log("error :>> ", error);
+    }
+  });
+};
+
+export const useThumbMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateThumb,
+    onSuccess: () => {
+      queryClient.invalidateQueries(queryKeys.boardController.feeds());
     }
   });
 };

--- a/src/queries/query.keys.js
+++ b/src/queries/query.keys.js
@@ -1,5 +1,6 @@
 export const queryKeys = {
   boardController: {
-    myFeeds: () => ["myFeeds"]
+    myFeeds: () => ["myFeeds"],
+    feeds: () => ["feeds"]
   }
 };


### PR DESCRIPTION
✅ 작업 사항
feed페이지 tanstackquery관련 로직 분리

📌 변경 사항
![image](https://github.com/user-attachments/assets/90ca2271-63c0-408f-96ee-19b78129ad97)
![image](https://github.com/user-attachments/assets/32aa1d59-7189-4ef0-89f7-f0e1fd09ec61)
전체 피드목록 관련 infiniteQuery분리 및 querykey 분리

![image](https://github.com/user-attachments/assets/36cb1f45-ff5d-42d2-a902-79689b5699da)
![image](https://github.com/user-attachments/assets/58b23477-c9b7-4150-8c35-bd782be59eed)
좋아요 관련 mutation분리 및 querykey분리